### PR TITLE
adding capability to move channels between saved nodes

### DIFF
--- a/capacity/accept_capacity_change.js
+++ b/capacity/accept_capacity_change.js
@@ -43,7 +43,7 @@ const openTxType = '1';
     transaction_vout: <Replacement Channel Transaction Output Index Number>
   }
 */
-module.exports = ({channel, from, id, increase, lnd, logger}, cbk) => {
+module.exports = ({channel, from, id, increase, lnd, logger, migration}, cbk) => {
   return new Promise((resolve, reject) => {
     return asyncAuto({
       // Check arguments
@@ -218,6 +218,7 @@ module.exports = ({channel, from, id, increase, lnd, logger}, cbk) => {
           return getReplacementSignature({
             channel,
             lnd,
+            migration,
             output,
             id: parameters.id,
             unsigned: parseSignCapacityRequest(parameters).unsigned,
@@ -238,7 +239,6 @@ module.exports = ({channel, from, id, increase, lnd, logger}, cbk) => {
               id: parameters.id,
               signature: res.signature,
             });
-
             // Send the replacement signature for the change request
             success({records});
 

--- a/capacity/capacity_change_requests.js
+++ b/capacity/capacity_change_requests.js
@@ -77,6 +77,7 @@ module.exports = ({channels, requests}) => {
         from: channel.partner_public_key,
         id: request.id,
         increase: request.increase,
+        migration: request.migration,
         type: type ? request.type : undefined,
       };
     });

--- a/capacity/change_channel_capacity.js
+++ b/capacity/change_channel_capacity.js
@@ -88,7 +88,6 @@ module.exports = ({ask, delay, lnd, logger, migrate_lnd, saved_nodes}, cbk) => {
         'waitForProposal',
         ({waitForProposal}, cbk) =>
       {
-        // console.log(waitForProposal);
         return asyncDetectSeries(waitForProposal.requests, (request, cbk) => {
           return getNodeAlias({lnd, id: request.from}, (err, res) => {
             if (!!err) {
@@ -110,7 +109,7 @@ module.exports = ({ask, delay, lnd, logger, migrate_lnd, saved_nodes}, cbk) => {
             const changeType = hasType ? ` and make channel ${type}` : '';
             const message = () => {
               if(!!request.migration) {
-                return `${action} with ${peer}${by}${changeType} and migrate channel to ${request.migration}?`
+                return `Migrate channel (${id}) with ${peer} of capacity ${size} to ${request.migration}?`
               } else {
                 return `${action} with ${peer}${by}${changeType}?`;
               }

--- a/capacity/encode_change_request.js
+++ b/capacity/encode_change_request.js
@@ -1,10 +1,12 @@
 const {encodeBigSize} = require('bolt01');
+const {encodeTlvRecord} = require('bolt01');
 const {rawChanId} = require('bolt07');
 
 const channelFlagsType = '5';
 const channelIdRecordType = '2';
 const decreaseRecordType = '3';
 const increaseRecordType = '4';
+const migrateRecordType = '6';
 const requestIdRecordType = '1';
 const typeAsHex = type => Buffer.from([type]).toString('hex');
 
@@ -26,7 +28,7 @@ const typeAsHex = type => Buffer.from([type]).toString('hex');
     }]
   }
 */
-module.exports = ({channel, decrease, id, increase, type}) => {
+module.exports = ({channel, decrease, id, increase, migration, type}) => {
   const records = [
     {
       type: requestIdRecordType,
@@ -48,6 +50,14 @@ module.exports = ({channel, decrease, id, increase, type}) => {
       type: decreaseRecordType,
       value: encodeBigSize({number: decrease.toString()}).encoded,
     });
+  }
+  
+  if (!!migration) {
+    // Add a record reflecting the migration of channel
+    records.push({
+      type: migrateRecordType,
+      value: migration,
+    })
   }
 
   if (!!increase) {

--- a/capacity/get_capacity_replacement.js
+++ b/capacity/get_capacity_replacement.js
@@ -302,7 +302,7 @@ module.exports = (args, cbk) => {
             partner_public_key: pendingChannel.partner_public_key,
           }],
           is_avoiding_broadcast: true,
-          lnd: args.lnd,
+          lnd: args.migrate_lnd || args.lnd,
         },
         cbk);
       }],

--- a/capacity/get_replacement_signature.js
+++ b/capacity/get_replacement_signature.js
@@ -35,7 +35,7 @@ const txIdAsHash = id => Buffer.from(id, 'hex').reverse();
     transaction_vout: <Replacement Transaction Output Index Number>
   }
 */
-module.exports = ({channel, id, lnd, output, unsigned, vout}, cbk) => {
+module.exports = ({channel, id, lnd, output, migration, unsigned, vout}, cbk) => {
   return new Promise((resolve, reject) => {
     return asyncAuto({
       // Check arguments
@@ -164,8 +164,8 @@ module.exports = ({channel, id, lnd, output, unsigned, vout}, cbk) => {
                 return false;
               }
 
-              // The new channel must be from the same peer
-              if (channel.partner_public_key !== pending.partner_public_key) {
+              // The new channel must be from the same peer or the migrating node pubkey
+              if (channel.partner_public_key !== pending.partner_public_key && channel.partner_public_key !== migration) {
                 return false;
               }
 

--- a/capacity/parse_capacity_change_request.js
+++ b/capacity/parse_capacity_change_request.js
@@ -86,8 +86,8 @@ module.exports = ({from, records}) => {
   const id = idRecord.value;
   const type = typeRecord ? hexAsNumber(typeRecord.value) : undefined;
 
-  // Exit early when there is no decrease or increase
-  if (!decreaseRecord && !increaseRecord) {
+  // Exit early when there is no decrease, increase or migration record
+  if (!decreaseRecord && !increaseRecord && !migrationRecord) {
     return {request: {channel, from, id, type}};
   }
 

--- a/capacity/parse_capacity_change_request.js
+++ b/capacity/parse_capacity_change_request.js
@@ -1,8 +1,10 @@
 const {chanFormat} = require('bolt07');
 const {decodeBigSize} = require('bolt01');
+const {decodeTlvRecord} = require('bolt01');
 
 const channelIdHexLength = 16;
 const decodeNumber = encoded => BigInt(decodeBigSize({encoded}).decoded);
+const decodePubkey = encoded => decodeTlvRecord({encoded});
 const defaultRecord = {value: '00'};
 const hexAsNumber = n => Buffer.from(n, 'hex').readUInt8();
 const idHexLength = 64;
@@ -11,6 +13,7 @@ const tooLarge = BigInt(Number.MAX_SAFE_INTEGER);
 const findChannelRecord = records => records.find(n => n.type === '2');
 const findDecreaseRecord = records => records.find(n => n.type === '3');
 const findIncreaseRecord = records => records.find(n => n.type === '4');
+const findMigrationRecord = records => records.find(n => n.type === '6');
 const findRequestIdRecord = records => records.find(n => n.type === '1');
 const findTypeRecord = records => records.find(n => n.type === '5');
 const findVersionRecord = records => records.find(n => n.type === '0');
@@ -71,6 +74,7 @@ module.exports = ({from, records}) => {
 
   const decreaseRecord = findDecreaseRecord(records);
   const increaseRecord = findIncreaseRecord(records);
+  const migrationRecord = findMigrationRecord(records);
   const typeRecord = findTypeRecord(records);
 
   // Exit early when there is a change in both directions
@@ -103,6 +107,7 @@ module.exports = ({from, records}) => {
       type,
       decrease: Number(decrease) || undefined,
       increase: Number(increase) || undefined,
+      migration: !!migrationRecord ? migrationRecord.value : undefined,
     },
   };
 };

--- a/capacity/propose_capacity_change.js
+++ b/capacity/propose_capacity_change.js
@@ -26,7 +26,7 @@ const findSignatureRecord = records => records.find(n => n.type === '1');
 const {fromHex} = Transaction;
 const fuzzHeight = 3;
 const maxSigHexLength = 146;
-const peerRequestTimeoutMs = 1000 * 30;
+const peerRequestTimeoutMs = 1000 * 60 * 10;
 const rebroadcastDelayMs = 1000 * 3;
 const {SIGHASH_ALL} = Transaction;
 const transitFamily = 805;


### PR DESCRIPTION
Pulls saved nodes list and populates as choices to pick from to migrate a channel to a saved node.

Files changed:

- capacity/accept_capacity_change.js
- capacity/ask_for_change_details.js
- capacity/capacity_change_requests.js
- capacity/change_channel_capacity.js
- capacity/encode_change_request.js
- capacity/get_capacity_replacement.js
- capacity/get_replacement_signature.js
- capacity/initiate_capacity_change.js
- capacity/parse_capacity_change_request.js
- capacity/propose_capacity_change.js