### PR TITLE
Sell channels using trade secret

### DIFF
--- a/service_types.json
+++ b/service_types.json
@@ -3,6 +3,8 @@
   "serviceTypeChangeCapacity": "8050001",
   "serviceTypeReceiveTrades": "8050006",
   "serviceTypeRequestTrades": "8050005",
+  "serviceTypeReceiveChannelSale": "8050008",
+  "serviceTypeRequestChannelSale": "8050007",
   "serviceTypeSignCapacityChange": "8050004",
   "serviceTypeWaitOnConfirmation": "8050003",
   "types": {
@@ -11,6 +13,8 @@
     "8050003": "serviceTypeWaitOnConfirmation",
     "8050004": "serviceTypeSignCapacityChange",
     "8050005": "serviceTypeRequestTrades",
-    "8050006": "serviceTypeReceiveTrades"
+    "8050006": "serviceTypeReceiveTrades",
+    "8050007": "serviceTypeRequestChannelSale",
+    "8050008": "serviceTypeReceiveChannelSale"
   }
 }

--- a/trades/create_channel_sale.js
+++ b/trades/create_channel_sale.js
@@ -1,0 +1,236 @@
+const asyncAuto = require('async/auto');
+const asyncReflect = require('async/reflect');
+const {returnResult} = require('asyncjs-util');
+const {getNetwork} = require('ln-sync');
+const {getChainFeeRate} = require('ln-service');
+const {getChannels} = require('ln-service');
+const {getWalletInfo} = require('ln-service');
+const {randomBytes} = require('crypto');
+const createAnchoredTrade = require('./create_anchored_trade');
+const serviceOpenTrade = require('./service_open_trade');
+
+// const serviceChannelSale = require('../sales/service_channel_sale');
+
+const asNumber = n => parseFloat(n, 10);
+const defaultExpirationDays = 1;
+const daysAsMs = days => Number(days) * 1000 * 60 * 60 * 24;
+const futureDate = ms => new Date(Date.now() + ms).toISOString();
+const isNumber = n => !isNaN(n);
+const slowTarget = 1000;
+const saleCost = (amount, rate) => (amount * rate / 1000000).toFixed(0);
+const saleSecret = randomBytes(48).toString('hex');
+const sellAction = 'sell';
+const tradeDescription = (alias, capacity) => `channel-sale:${alias}--${capacity}`;
+
+
+
+module.exports = ({action, balance, ask, lnd, logger}, cbk) => {
+  return new Promise((resolve, reject) => {
+    return asyncAuto({
+      // Check arguments
+      validate: cbk => {
+        if (!action) {
+          return cbk([400, 'ExpectedActionTypeToCreateChannelSale']);
+        }
+
+        if (balance === undefined) {
+          return cbk([400, 'ExpectedOnChainBalanceToCreateChannelSale']);
+        }
+
+        if (!ask) {
+          return cbk([400, 'ExpectedAskFunctionToCreateChannelSale']);
+        }
+
+        if (!lnd) {
+          return cbk([400, 'ExpectedLndToCreateChannelSale']);
+        }
+
+        if (!logger) {
+          return cbk([400, 'ExpectedLoggerToCreateChannelSale']);
+        }
+
+        return cbk();
+      },
+
+      //Get Identiy
+      getIdentity: ['validate', ({}, cbk) => {
+        return getWalletInfo({lnd}, cbk);
+      }],
+
+      // Get the public channels to use for an open trade
+      getChannels: ['validate', ({}, cbk) => {
+        return getChannels({lnd, is_public: true}, cbk);
+      }],
+
+      // Get the network name to use for an open trade
+      getNetwork: ['validate', ({}, cbk) => {
+        return getNetwork({lnd}, cbk);
+      }],
+
+      // Ask for sale amount 
+      askForAmount: ['validate', ({}, cbk) => {
+        return ask({
+          message: `How much would you like to sell? (Available balance: ${balance})`,
+          name: 'amount',
+          type: 'input',
+          validate: input => {
+            if (!input) {
+              return false;
+            }
+
+            // The connect code should be entirely numeric, not an API key
+            if (!isNumber(input)) {
+              return `Expected numeric amount for sale`;
+            }
+
+            if (input > balance) {
+              return `Sale amount must be less than available balance`;
+            }
+
+            return true;
+          },
+        },
+        (err, result) => {
+          if (!!err) {
+            return cbk([503, 'UnexpectedErrorAskingForSaleAmount', err]);
+          }
+
+          return cbk(null, result);
+        });
+      }],
+
+      // Ask for rate
+      askForRate: ['validate', 'askForAmount', ({}, cbk) => {
+        return ask({
+          message: 'Rate to charge in ppm?',
+          name: 'rate',
+          type: 'input',
+          validate: input => {
+            if (!input) {
+              return false;
+            }
+
+            // The connect code should be entirely numeric, not an API key
+            if (!isNumber(input)) {
+              return `Expected numeric fee rate for sale`;
+            }
+
+            return true;
+          },
+        },
+        (err, result) => {
+          if (!!err) {
+            return cbk([503, 'UnexpectedErrorAskingForRate', err]);
+          }
+
+          return cbk(null, result);
+        });
+      }],
+
+      // Calculate sale cost
+      saleCost: ['askForAmount', 'askForRate', ({askForRate, askForAmount}, cbk) => {
+        const {amount} = askForAmount;
+        const {rate} = askForRate;
+
+        const cost = saleCost(amount, rate);
+
+        return cbk(null, cost);
+      }],
+
+      // Ask for the expiration of the channel sale
+      askForExpiration: ['askForRate', ({}, cbk) => {
+        return ask({
+          default: defaultExpirationDays,
+          name: 'days',
+          message: 'Days to offer this for?',
+          validate: input => {
+            if (!isNumber(input) || !Number(input)) {
+              return false;
+            }
+
+            return true;
+          },
+        },
+        cbk);
+      }],
+
+      // Create an anchor invoice for the channel sale
+      createAnchor: [
+        'askForAmount',
+        'askForExpiration',
+        'askForRate',
+        'getIdentity',
+        'saleCost',
+        ({
+          askForAmount,
+          askForExpiration,
+          askForRate,
+          getIdentity,
+          saleCost,
+        },
+        cbk) =>
+      {
+        return createAnchoredTrade({
+          lnd,
+          description: tradeDescription(getIdentity.alias, askForAmount.amount),
+          expires_at: futureDate(daysAsMs(askForExpiration.days)),
+          secret: saleSecret,
+          tokens: asNumber(saleCost),
+        },
+        cbk);
+      }],
+
+      // Wait for a peer to connect and ask for the channel sale details
+      serviceSaleRequests: [
+        'askForAmount',
+        'askForExpiration',
+        'createAnchor',
+        'getChannels',
+        'getNetwork',
+        'getIdentity',
+        ({
+          askForAmount,
+          askForExpiration,
+          createAnchor,
+          getChannels,
+          getNetwork,
+          getIdentity,
+          saleCost,
+        },
+        cbk) =>
+      {
+        return serviceOpenTrade({
+          action,
+          lnd,
+          logger,
+          capacity: askForAmount.amount,
+          channels: getChannels.channels,
+          description: tradeDescription(getIdentity.alias, askForAmount.amount),
+          expires_at: futureDate(daysAsMs(askForExpiration.days)),
+          id: createAnchor.id,
+          network: getNetwork.network,
+          public_key: getIdentity.public_key,
+          secret: saleSecret,
+          tokens: asNumber(saleCost),
+          uris: (getIdentity.uris || []),
+        },
+        cbk);
+      }],
+
+      // Encode channel sale
+      result: [
+        'askForAmount',
+        'askForExpiration',
+        'createAnchor',
+        'getIdentity',
+        'askForRate',
+        'validate',
+        ({}, cbk) => {
+          return cbk();
+        }],
+
+
+    },
+    returnResult({reject, resolve, of: 'result'}, cbk));
+  });
+};

--- a/trades/create_channel_sale.js
+++ b/trades/create_channel_sale.js
@@ -5,6 +5,7 @@ const {getNetwork} = require('ln-sync');
 const {getChainFeeRate} = require('ln-service');
 const {getChannels} = require('ln-service');
 const {getWalletInfo} = require('ln-service');
+const {signMessage} = require('ln-service');
 const {randomBytes} = require('crypto');
 const createAnchoredTrade = require('./create_anchored_trade');
 const serviceOpenTrade = require('./service_open_trade');
@@ -20,7 +21,7 @@ const slowTarget = 1000;
 const saleCost = (amount, rate) => (amount * rate / 1000000).toFixed(0);
 const saleSecret = randomBytes(48).toString('hex');
 const sellAction = 'sell';
-const tradeDescription = (alias, capacity) => `channel-sale:${alias}--${capacity}`;
+const tradeDescription = (alias, capacity) => `channelsale:${alias}-${capacity}`;
 
 
 

--- a/trades/finalize_trade_secret.js
+++ b/trades/finalize_trade_secret.js
@@ -71,7 +71,7 @@ module.exports = (args, cbk) => {
       },
 
       // Get low fee rate
-      calculateOpenFee: ['validate', ({}, cbk) => {
+      calculateSalePrice: ['validate', ({}, cbk) => {
         if (args.action !== sellAction) {
           return cbk(null, {});
         }
@@ -104,7 +104,7 @@ module.exports = (args, cbk) => {
       }],
 
       // Create the invoice to purchase the unlocking secret
-      createInvoice: ['encrypt', 'calculateOpenFee', ({encrypt, calculateOpenFee}, cbk) => {
+      createInvoice: ['encrypt', 'calculateSalePrice', ({encrypt, calculateSalePrice}, cbk) => {
         // Exit early when this is a hold invoice
         if (!!args.is_hold) {
           return createHodlInvoice({
@@ -113,7 +113,7 @@ module.exports = (args, cbk) => {
             id: bufferAsHex(sha256(hexAsBuffer(encrypt.payment_secret))),
             lnd: args.lnd,
             secret: encrypt.payment_secret,
-            tokens: calculateOpenFee.totalSaleCost || args.tokens,
+            tokens: calculateSalePrice.totalSaleCost || args.tokens,
           },
           cbk);
         }

--- a/trades/manage_trade.js
+++ b/trades/manage_trade.js
@@ -28,11 +28,15 @@ const tokensAsBigUnit = tokens => (tokens / 1e8).toFixed(8);
 
   @returns via cbk or Promise
 */
-module.exports = ({ask, lnd, logger}, cbk) => {
+module.exports = ({action, ask, lnd, logger}, cbk) => {
   return new Promise((resolve, reject) => {
     return asyncAuto({
       // Check arguments
       validate: cbk => {
+        if (!action) {
+          return cbk([400, 'ExpectedActionTypeToManageTrade']);
+        }
+
         if (!ask) {
           return cbk([400, 'ExpectedAskFunctionToManageTrade']);
         }
@@ -90,6 +94,7 @@ module.exports = ({ask, lnd, logger}, cbk) => {
 
         // Get the trade details interactively
         return findTrade({
+          action,
           ask,
           lnd,
           logger,

--- a/trades/manage_trades.js
+++ b/trades/manage_trades.js
@@ -39,7 +39,7 @@ const viewAction = 'view';
 
   @returns via cbk or Promise
 */
-module.exports = ({ask, balance, lnd, logger, separator}, cbk) => {
+module.exports = ({ask, balance, experimental, lnd, logger, separator}, cbk) => {
   return new Promise((resolve, reject) => {
     return asyncAuto({
       // Check arguments
@@ -74,11 +74,11 @@ module.exports = ({ask, balance, lnd, logger, separator}, cbk) => {
         return ask({
           choices: [
             separator(),
-            {name: 'Buy Channel', value: buyAction},
-            {name: 'Sell Channel', value: sellAction},
-            separator(),
             {name: 'Create Trade', value: createAction},
             {name: 'Decode Trade', value: decodeAction},
+            separator(),
+            {name: 'Buy Channel (experimental)', value: buyAction, disabled: !experimental},
+            {name: 'Sell Channel (experimental)', value: sellAction, disabled: !experimental},
             separator(),
             {name: 'Open Trades', value: listAction},
             {name: 'Serve Trades', value: serveAction},

--- a/trades/network_record_from_request.js
+++ b/trades/network_record_from_request.js
@@ -20,7 +20,7 @@ module.exports = ({request}) => {
     throw new Error('ExpectedPaymentRequestToDeriveNetworkRecord');
   }
 
-  if (request.startsWith(defaultNetwork)) {
+  if (request.startsWith(defaultNetwork) && !request.startsWith(regtestNetwork)) {
     return {};
   }
 

--- a/trades/network_record_from_request.js
+++ b/trades/network_record_from_request.js
@@ -1,7 +1,9 @@
-const defaultNetwork = 'lnbc';
-const regtestNetwork = 'lnbcrt';
+const {parsePaymentRequest} = require('ln-service');
+
+const defaultNetwork = 'bitcoin';
+const regtestNetwork = 'regtest';
 const regtestNetworkType = '02';
-const testnetNetwork = 'lntb';
+const testnetNetwork = 'testnet';
 const testnetNetworkType = '01';
 
 /** Derive a network record name from a payment request
@@ -20,17 +22,25 @@ module.exports = ({request}) => {
     throw new Error('ExpectedPaymentRequestToDeriveNetworkRecord');
   }
 
-  if (request.startsWith(defaultNetwork) && !request.startsWith(regtestNetwork)) {
-    return {};
+  try {
+    const {network} = parsePaymentRequest({request});
+
+    if (network === defaultNetwork) {
+      return {};
+    }
+  
+    if (network === regtestNetwork) {
+      return {value: regtestNetworkType};
+    }
+  
+    if (network === testnetNetwork) {
+      return {value: testnetNetworkType};
+    }
+  
+    throw new Error('UnknownNetworkToDeriveNetworkRecordFor');
+
+  } catch (err) {
+    throw new Error('FailedToParsePaymentRequestToDeriveNetworkRecord');
   }
 
-  if (request.startsWith(regtestNetwork)) {
-    return {value: regtestNetworkType};
-  }
-
-  if (request.startsWith(testnetNetwork)) {
-    return {value: testnetNetworkType};
-  }
-
-  throw new Error('UnknownNetworkToDeriveNetworkRecordFor');
 };

--- a/trades/open_channel.js
+++ b/trades/open_channel.js
@@ -1,24 +1,35 @@
 const asyncAuto = require('async/auto');
 const {returnResult} = require('asyncjs-util');
-
 const {getPeers} = require('ln-service');
 const {getChainFeeRate} = require('ln-service');
 const {openChannel} = require('ln-service');
 
 const slowConf = 144;
 
+/** Opens channel on invoice payment
+  {
+    id: <Partner Public Key>
+    lnd: <Authenticated LND API Object>
+    tokens: <Capacity of channel open>
+  }
 
+  @returns via cbk or Promise
+  {
+  transaction_id: <Funding Transaction Id String>
+  transaction_vout: <Funding Transaction Output Index Number>
+  }
+*/
 module.exports = (args, cbk) => {
   return new Promise((resolve, reject) => {
     return asyncAuto({
       // Check arguments
       validate: cbk => {
-        if (!args.lnd) {
-          return cbk([400, 'ExpectedLndObjectToOpenNewChannel']);
-        }
-
         if (!args.id) {
           return cbk([400, 'ExpectedPartnerPublicKeyToOpenNewChannel']);
+        }
+
+        if (!args.lnd) {
+          return cbk([400, 'ExpectedLndObjectToOpenNewChannel']);
         }
 
         if (!args.tokens) {

--- a/trades/open_channel.js
+++ b/trades/open_channel.js
@@ -1,0 +1,71 @@
+const asyncAuto = require('async/auto');
+const {returnResult} = require('asyncjs-util');
+
+const {getPeers} = require('ln-service');
+const {getChainFeeRate} = require('ln-service');
+const {openChannel} = require('ln-service');
+
+const slowConf = 144;
+
+
+module.exports = (args, cbk) => {
+  return new Promise((resolve, reject) => {
+    return asyncAuto({
+      // Check arguments
+      validate: cbk => {
+        if (!args.lnd) {
+          return cbk([400, 'ExpectedLndObjectToOpenNewChannel']);
+        }
+
+        if (!args.id) {
+          return cbk([400, 'ExpectedPartnerPublicKeyToOpenNewChannel']);
+        }
+
+        if (!args.tokens) {
+          return cbk([400, 'ExpectedCapacityToOpenNewChannel']);
+        }
+
+        return cbk();
+      },
+
+      // Get low fee rate
+      getSlowFee: ['validate', ({}, cbk) => {
+        return getChainFeeRate({
+          confirmation_target: slowConf,
+          lnd: args.lnd,
+        },
+        cbk);
+      }],
+
+      getSocket: ['validate', ({}, cbk) => {
+        return getPeers(
+          {
+            lnd: args.lnd,
+          }, 
+          (err, res) => {
+            const peer = res.peers.find(n => n.public_key === args.id);
+            return cbk(null, {socket: peer.socket});
+          });
+      }],
+
+      // Select a peer and open a channel
+      openChannel: [
+        'getSlowFee',
+        'getSocket',
+        'validate',
+        ({getSlowFee, getSocket}, cbk) =>
+      {
+        return openChannel({
+          chain_fee_rate: getSlowFee.tokens_per_vbyte,
+          lnd: args.lnd,
+          local_tokens: args.tokens,
+          partner_public_key: args.id,
+          partner_socket: getSocket.socket
+        },
+        cbk);
+      }],
+
+    },
+    returnResult({reject, resolve, of: 'openChannel'}, cbk));
+  });
+};

--- a/trades/service_open_trade.js
+++ b/trades/service_open_trade.js
@@ -14,6 +14,8 @@ const uriAsSocket = n => n.substring(67);
 /** Service an individual trade
 
   {
+    action: <Ask function action>
+    capacity: <Capacity of channel open in satoshis>
     channels: [{
       id: <Standard Format Channel Id String>
       partner_public_key: <Node Public Key Hex String>

--- a/trades/service_open_trade.js
+++ b/trades/service_open_trade.js
@@ -3,7 +3,6 @@ const {getNodeAlias} = require('ln-sync');
 const {returnResult} = require('asyncjs-util');
 
 const encodeOpenTrade = require('./encode_open_trade');
-const openChannel = require('./open_channel');
 const serviceTradeRequests = require('./service_trade_requests');
 
 const asNumber = n => parseFloat(n, 10);
@@ -109,6 +108,7 @@ module.exports = (args, cbk) => {
           expires_at: args.expires_at,
           id: args.id,
           lnd: args.lnd,
+          logger: args.logger,
           secret: args.secret,
           tokens: asNumber(args.tokens),
         });
@@ -157,16 +157,6 @@ module.exports = (args, cbk) => {
               args.logger.info({trade_ended: true});
 
               return cbk();
-            }
-
-            if (!!args.action) {
-              const transactionId = await openChannel({
-                lnd: args.lnd,
-                id: to,
-                tokens: args.capacity,
-              });
-              
-              args.logger.info({channel_opened: transactionId});
             }
 
             const {alias, id} = await getNodeAlias({id: to, lnd: args.lnd});

--- a/trades/service_trade_requests.js
+++ b/trades/service_trade_requests.js
@@ -33,10 +33,12 @@ const utf8AsHex = utf8 => Buffer.from(utf8).toString('hex');
   The maximum expiration date is three weeks
 
   {
+    action: <Ask function action>
     description: <Trade Description String>
     expires_at: <Trade Expires At ISO 8601 Date String>
     id: <Trade Id Hex String>
     lnd: <Authenticated LND API Object>
+    logger: <Winston Logger Object>
     secret: <Secret Payload String>
     tokens: <Tokens Number>
   }
@@ -212,10 +214,12 @@ module.exports = args => {
 
     // Create a trade secret for the requesting peer and return that
     return finalizeTradeSecret({
+      action: args.action,
       description: args.description,
       expires_at: args.expires_at,
       is_hold: true,
       lnd: args.lnd,
+      logger: args.logger,
       secret: args.secret,
       to: req.from,
       tokens: args.tokens,


### PR DESCRIPTION
Added two new options to trade-secret called buy channel and sell channel.
They have their own service types `8050007` and `8050008` so these trades don't respond to regular open trades.

I tried adding a signed message as the secret to show as proof of channel sale but looks like a signed message is about 104 chars and the limit is 100chars so for now its just a random string.


Files changed:
service_types.json
accept__trade.js
create_channel_sale.js
find_trade.js
manage_trade.js
manage_trades.js
network_record_from_request.js
open_channel.js
request_trade_by_id.js
service_open_trade.js
service_trade_requests.js